### PR TITLE
Add Agent QA to official developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Official integrations are maintained by companies building production ready MCP 
 
 ### Developer Tools & DevOps
 
+- **[Agent QA](https://github.com/vostride/agent-qa)** - Run natural-language web and mobile regression tests with persistent test memory through CLI and MCP interfaces.
 - **[AgentRPC](https://github.com/agentrpc/agentrpc)** - Connect to any function, any language, across network boundaries using [AgentRPC](https://www.agentrpc.com/).
 - **[AlibabaCloud DevOps MCP](https://github.com/aliyun/alibabacloud-devops-mcp-server)** - Yunxiao MCP Server provides AI assistants with the ability to interact with the [Yunxiao platform](https://devops.aliyun.com).
 - **[APIMatic MCP](https://github.com/apimatic/apimatic-validator-mcp)** - APIMatic MCP Server is used to validate OpenAPI specifications using [APIMatic](https://www.apimatic.io/). The server processes OpenAPI files and returns validation summaries by leveraging APIMatic's API.


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) to Official Servers → Developer Tools & DevOps.

This placement follows the contribution guide's definition of an official server: Agent QA's MCP server is maintained by Vostride, the organization that builds the project. The one-sentence entry is factual and limited to natural-language web/mobile regression testing, persistent test memory, and its CLI/MCP interfaces.

## Validation

- confirmed the public repository is functional and Agent QA was not already listed or proposed by this account
- kept the entry alphabetically before AgentRPC
- verified the canonical link through the GitHub API
- `git diff --check` passes

Disclosure: I am affiliated with Agent QA. FSL-1.1-ALv2 is source-available rather than OSI open source, and each release converts to Apache-2.0 after two years. Configured model-provider accounts and usage charges are separate.
